### PR TITLE
Make Collabora autonomously obtain its own port from KTP apps API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM collabora/code:24.04.2.1.1
 
 COPY coolwsd.xml /etc/coolwsd/coolwsd.xml
+COPY start.sh /start.sh
 
 # Disable welcome message
 USER root
 RUN sed -i "s|%ENABLE_WELCOME_MSG%|false|g" /usr/share/coolwsd/browser/dist/cool.html
 USER cool
+
+CMD [ "/start.sh" ]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Determine own port and update that into coolwsd.xml
+echo "Attempting to connect to KTP apps API to obtain own port number"
+
+SELF_PORT="$(curl \
+  -sSL \
+  --retry 10 \
+  --retry-delay 0 \
+  --retry-max-time 60 \
+  --retry-connrefused \
+  "http://ktpjs:$KTP_REST_PORT/apps/collabora/port"
+)"
+
+SERVER_NAME="$HOST_NAME:$SELF_PORT"
+echo "Port number obtained, replacing server name in coolwsd.xml with '$SERVER_NAME'"
+sed -i "s|>.*</server_name>|>$SERVER_NAME</server_name>|g" /etc/coolwsd/coolwsd.xml
+
+# Then start Collabora proper
+exec /start-collabora-online.sh --nodaemon


### PR DESCRIPTION
Collabora-kontti kysyy nyt porttinsa KTP:n uudesta apps-API:n endpointista `/apps/collabora/port`, jotta sitä ei tarvitse tietää buildivaiheessa. Tämä on esivaatimus sille, että voidaan ajaa useampaa kuin yhtä Collabora-instanssia (ja siten KTP:tä) samalla koneella.