### PR TITLE
Disable Collabora proofreading tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,23 @@ FROM collabora/code:24.04.13.3.1
 COPY coolwsd.xml /etc/coolwsd/coolwsd.xml
 COPY start.sh /start.sh
 
-# Disable welcome message
+# Image content modification steps
 USER root
+
+# Disable welcome message
 RUN sed -i "s|%ENABLE_WELCOME_MSG%|false|g" /usr/share/coolwsd/browser/dist/cool.html
+
+# Disable feedback popup
+RUN sed -i "s|%AUTO_SHOW_FEEDBACK%|false|g" /usr/share/coolwsd/browser/dist/cool.html
+
+# Remove autocorrect, autotext etc. features
+RUN rm -rf /opt/collaboraoffice/share/autocorr/*
+RUN rm -rf /opt/collaboraoffice/share/autotext/*
+RUN rm -rf /opt/collaboraoffice/share/extensions/*
+RUN rm -rf /opt/collaboraoffice/share/wordbook/*
+RUN rm -rf /opt/collaboraoffice/share/fingerprint/*
+RUN rm -rf /opt/collaboraoffice/share/numbertext/*
+
 USER cool
 
 CMD [ "/start.sh" ]

--- a/coolwsd.xml
+++ b/coolwsd.xml
@@ -11,7 +11,7 @@
         <enable type="bool" desc="Controls whether accessibility support should be enabled or not." default="false">false</enable>
     </accessibility>
 
-    <allowed_languages desc="List of supported languages of Writing Aids (spell checker, grammar checker, thesaurus, hyphenation) on this instance. Allowing too many has negative effect on startup performance." default="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru">de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru</allowed_languages>
+    <allowed_languages desc="List of supported languages of Writing Aids (spell checker, grammar checker, thesaurus, hyphenation) on this instance. Allowing too many has negative effect on startup performance." default="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru"></allowed_languages>
 
     <!--
         These are the settings of external (remote) spellchecker and grammar checker services. Currently LanguageTool and Duden Korrekturserver APIs are supported, you can


### PR DESCRIPTION
Poistetaan Collaborasta oikoluvut, sanakirjat tms. kirjoitusapuvälineet.

Muutos coolwsd.xml:ään on enimmäkseen siitä syystä, ettei se antaisi väärää kuvaa siitä mitkä kielet ovat oikeasti käytössä, mutta tuon arvon muuttaminen itsessään ei vaikuta tekevän mitään. Default-kentän muuttaminen ei myöskään auttanut; oletan että se ei oikeasti ohjaa oletusarvoa, vaan ainoastaan kertoo, miksi se oletusarvo on asetettu jossain koodin syövereissä. Arvaisin, että tämä defaultti enabloituu kun arvo on tyhjä, koska Collaboraa tuskin on rakennettu sellaisen käyttötapauksen ympärille missä ei pidä olla mitään oikolukuja tms. saatavilla.

Ainoa löytämäni toimiva tapa oli tyhjentää oikoluvun tms. ohjaustiedostot kontin levyltä imagen koontivaiheessa. Tämä on muutenkin varmin tapa, koska se tarkoittaa sitä, että oikolukuja ei saa noin vaan vivusta päälle, vaikka sattuisikin pääsemään peukaloimaan coolwsd.xml:ää.