### PR TITLE
Enable WOPI proof mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ COPY start.sh /start.sh
 # Image content modification steps
 USER root
 
+# Create WOPI proof mount volume so cool user can write to it
+RUN mkdir -p /mnt/wopi-proof
+RUN chown cool:cool /mnt/wopi-proof
+
 # Disable welcome message
 RUN sed -i "s|%ENABLE_WELCOME_MSG%|false|g" /usr/share/coolwsd/browser/dist/cool.html
 
@@ -22,4 +26,4 @@ RUN rm -rf /opt/collaboraoffice/share/numbertext/*
 
 USER cool
 
-CMD [ "/start.sh" ]
+ENTRYPOINT [ "/start.sh" ]

--- a/start.sh
+++ b/start.sh
@@ -18,5 +18,13 @@ SERVER_NAME="$HOST_NAME:$SELF_PORT"
 echo "Port number obtained, replacing server name in coolwsd.xml with '$SERVER_NAME'"
 sed -i "s|>.*</server_name>|>$SERVER_NAME</server_name>|g" /etc/coolwsd/coolwsd.xml
 
+# Generate Collabora WOPI proof and copy public key to WOPI proof volume
+coolconfig generate-proof-key
+
+# Copy WOPI proof public key to volume
+# Private key is not copied. We'll use public key decryption on the KTP end
+# to validate the request without exposing the private key
+cp /etc/coolwsd/proof_key.pub /mnt/wopi-proof/collabora-wopi-proof.pub
+
 # Then start Collabora proper
-exec /start-collabora-online.sh --nodaemon
+exec /start-collabora-online.sh


### PR DESCRIPTION
Enabloidaan https://sdk.collaboraonline.com/docs/advanced_integration.html?highlight=wopisrc#wopi-proof, jotta voidaan validoida, että kaikki WOPI-pyynnöt tulevat Collaboralta eivätkä miltään muulta.

Vaatii tämän toimiakseen: https://github.com/digabi/digabi2-app-config/pull/62
KTP:n puolen PR: https://github.com/digabi/digabi2/pull/928