### PR TITLE
Reject egress traffic from Collabora using `iptables`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ USER root
 RUN mkdir -p /mnt/wopi-proof
 RUN chown cool:cool /mnt/wopi-proof
 
+# Install minimal tooling for container egress filtering.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iptables \
+    && rm -rf /var/lib/apt/lists/*
+
 # Disable welcome message
 RUN sed -i "s|%ENABLE_WELCOME_MSG%|false|g" /usr/share/coolwsd/browser/dist/cool.html
 
@@ -23,7 +28,5 @@ RUN rm -rf /opt/collaboraoffice/share/extensions/*
 RUN rm -rf /opt/collaboraoffice/share/wordbook/*
 RUN rm -rf /opt/collaboraoffice/share/fingerprint/*
 RUN rm -rf /opt/collaboraoffice/share/numbertext/*
-
-USER cool
 
 ENTRYPOINT [ "/start.sh" ]

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,41 @@
 
 set -euo pipefail
 
+# We need to run iptables as root to set up the egress firewall.
+# For the rest of the operations, we can drop privileges to the 'cool' user.
+run_as_cool() {
+  setpriv \
+    --reuid=cool \
+    --regid=cool \
+    --init-groups \
+    "$@"
+}
+
+configure_egress_firewall() {
+  local address
+  local host
+
+  echo "Configuring Collabora egress firewall"
+
+  # Allows packets that belong to an already-established connection (e.g., responses to incoming requests)
+  iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+  # Allow egress to localhost
+  iptables -A OUTPUT -d 127.0.0.0/8 -j ACCEPT
+
+  # Allow egress to needed KTP hosts (ktp, ktpjs, and the host)
+  for host in ktp ktpjs "$HOST_NAME"; do
+    address="$(getent ahostsv4 "$host" | awk '{ print $1; exit }')"
+    echo "Allowing egress to $host ($address)"
+    iptables -A OUTPUT -d "$address" -j ACCEPT
+  done
+
+  # Reject all other egress traffic
+  iptables -A OUTPUT -j REJECT
+}
+
+configure_egress_firewall
+
 # Determine own port and update that into coolwsd.xml
 echo "Attempting to connect to KTP apps API to obtain own port number"
 
@@ -19,12 +54,16 @@ echo "Port number obtained, replacing server name in coolwsd.xml with '$SERVER_N
 sed -i "s|>.*</server_name>|>$SERVER_NAME</server_name>|g" /etc/coolwsd/coolwsd.xml
 
 # Generate Collabora WOPI proof and copy public key to WOPI proof volume
-coolconfig generate-proof-key
+run_as_cool coolconfig generate-proof-key
 
 # Copy WOPI proof public key to volume
 # Private key is not copied. We'll use public key decryption on the KTP end
 # to validate the request without exposing the private key
-cp /etc/coolwsd/proof_key.pub /mnt/wopi-proof/collabora-wopi-proof.pub
+run_as_cool cp /etc/coolwsd/proof_key.pub /mnt/wopi-proof/collabora-wopi-proof.pub
 
-# Then start Collabora proper
-exec /start-collabora-online.sh
+# Then start Collabora proper as the 'cool' user
+exec setpriv \
+  --reuid=cool \
+  --regid=cool \
+  --init-groups \
+  /start-collabora-online.sh


### PR DESCRIPTION
Used `iptables` to prevent all egress traffic except for the required KTP hosts.